### PR TITLE
Fix widget sizes

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -84,6 +84,6 @@
 			</intent-filter>
 		</receiver>
     </application>
-    <uses-sdk android:minSdkVersion="3" />
+    <uses-sdk android:minSdkVersion="4" android:targetSdkVersion="4" />
 
 </manifest> 

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -24,6 +24,16 @@
 		</receiver>
 		
 		<receiver
+			android:name=".HandyNotes21"
+			android:label="@string/handy_note_21">
+			<intent-filter>
+				<action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+			</intent-filter>
+			<meta-data android:name="android.appwidget.provider"
+				android:resource="@xml/widget_21" />
+		</receiver>
+
+		<receiver
 			android:name=".HandyNotes33"
 			android:label="@string/handy_note_33">
 			<intent-filter>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -6,6 +6,7 @@
 <string name="update">Actualizar</string>
 <string name="handy_note_11">Nota accesible (1x1)</string>
 <string name="handy_note_22">Nota accesible (2x2)</string>
+<string name="handy_note_21">Nota accesible (2x1)</string>
 <string name="handy_note_33">Nota accesible (3x3)</string>
 <string name="handy_note_41">Nota accesible (4x1)</string>
 <string name="handy_note_42">Nota accesible (4x2)</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -6,6 +6,7 @@
 <string name="update">Update</string>
 <string name="handy_note_11">Handy note (1x1)</string>
 <string name="handy_note_22">Handy note (2x2)</string>
+<string name="handy_note_21">Handy note (2x1)</string>
 <string name="handy_note_33">Handy note (3x3)</string>
 <string name="handy_note_41">Handy note (4x1)</string>
 <string name="handy_note_42">Handy note (4x2)</string>

--- a/res/xml/widget_11.xml
+++ b/res/xml/widget_11.xml
@@ -2,7 +2,7 @@
 <appwidget-provider
   xmlns:android="http://schemas.android.com/apk/res/android"
   android:initialLayout="@layout/show_note"
-  android:minHeight="72dp"
-  android:minWidth="72dp"
+  android:minHeight="40dp"
+  android:minWidth="40dp"
   android:configure="net.tapi.handynotes.NewNote" >
 </appwidget-provider>

--- a/res/xml/widget_21.xml
+++ b/res/xml/widget_21.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:initialLayout="@layout/show_note"
+  android:minHeight="40dp"
+  android:minWidth="110dp"
+  android:configure="net.tapi.handynotes.NewNote" >
+</appwidget-provider>

--- a/res/xml/widget_22.xml
+++ b/res/xml/widget_22.xml
@@ -2,7 +2,7 @@
 <appwidget-provider
   xmlns:android="http://schemas.android.com/apk/res/android"
   android:initialLayout="@layout/show_note"
-  android:minHeight="146dp"
-  android:minWidth="146dp"
+  android:minHeight="110dp"
+  android:minWidth="110dp"
   android:configure="net.tapi.handynotes.NewNote" >
 </appwidget-provider>

--- a/res/xml/widget_33.xml
+++ b/res/xml/widget_33.xml
@@ -2,7 +2,7 @@
 <appwidget-provider
   xmlns:android="http://schemas.android.com/apk/res/android"
   android:initialLayout="@layout/show_note"
-  android:minHeight="220dp"
-  android:minWidth="220dp"
+  android:minHeight="180dp"
+  android:minWidth="180dp"
   android:configure="net.tapi.handynotes.NewNote" >
 </appwidget-provider>

--- a/res/xml/widget_41.xml
+++ b/res/xml/widget_41.xml
@@ -2,7 +2,7 @@
 <appwidget-provider
   xmlns:android="http://schemas.android.com/apk/res/android"
   android:initialLayout="@layout/show_note"
-  android:minHeight="72dp"
-  android:minWidth="294dp"
+  android:minHeight="40dp"
+  android:minWidth="250dp"
   android:configure="net.tapi.handynotes.NewNote" >
 </appwidget-provider>

--- a/res/xml/widget_42.xml
+++ b/res/xml/widget_42.xml
@@ -2,7 +2,7 @@
 <appwidget-provider
   xmlns:android="http://schemas.android.com/apk/res/android"
   android:initialLayout="@layout/show_note"
-  android:minHeight="146dp"
-  android:minWidth="294dp"
+  android:minHeight="110dp"
+  android:minWidth="250dp"
   android:configure="net.tapi.handynotes.NewNote" >
 </appwidget-provider>

--- a/res/xml/widget_44.xml
+++ b/res/xml/widget_44.xml
@@ -2,7 +2,7 @@
 <appwidget-provider
   xmlns:android="http://schemas.android.com/apk/res/android"
   android:initialLayout="@layout/show_note"
-  android:minHeight="294dp"
-  android:minWidth="294dp"
+  android:minHeight="250dp"
+  android:minWidth="250dp"
   android:configure="net.tapi.handynotes.NewNote" >
 </appwidget-provider>

--- a/src/net/tapi/handynotes/HandyNotes21.java
+++ b/src/net/tapi/handynotes/HandyNotes21.java
@@ -1,0 +1,5 @@
+package net.tapi.handynotes;
+
+public class HandyNotes21 extends HandyNotes {
+
+}


### PR DESCRIPTION
Fixes issue 9 (https://github.com/atd/HandyNotes/issues/9).

The calculation is apparently 70 x cells - 30.
